### PR TITLE
Adjust EctoFields.Atom to only dump valid strings and atoms.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  inputs: [".formatter.exs", "mix.exs", "{config,lib,priv,test}/**/*.{ex,exs}"],
+  line_length: 132
+]

--- a/lib/fields/atom.ex
+++ b/lib/fields/atom.ex
@@ -14,20 +14,28 @@ defmodule EctoFields.Atom do
 
       iex> EctoFields.Atom.cast(nil)
       {:ok, nil}
- """
+  """
   @behaviour Ecto.Type
-  def type, do: :string
 
+  @max_atom_length 0xFF
+
+  @impl Ecto.Type
+  def type(), do: :string
+
+  @impl Ecto.Type
   def cast(nil), do: {:ok, nil}
-  def cast(str) when is_binary(str), do: {:ok, String.to_atom(str)}
   def cast(atom) when is_atom(atom), do: {:ok, atom}
+  def cast(binary) when is_binary(binary) and byte_size(binary) <= @max_atom_length, do: {:ok, String.to_atom(binary)}
   def cast(_), do: :error
 
   # when loading from the database convert to an atom
-  def load(nil), do: {:ok, nil}
-  def load(str), do: {:ok, String.to_atom(str)}
+  @impl Ecto.Type
+  def load(term), do: cast(term)
 
   # save to the database
+  @impl Ecto.Type
   def dump(nil), do: {:ok, nil}
-  def dump(atom), do: {:ok, to_string(atom)}
+  def dump(atom) when is_atom(atom), do: {:ok, Atom.to_string(atom)}
+  def dump(binary) when is_binary(binary) and byte_size(binary) <= @max_atom_length, do: {:ok, binary}
+  def dump(_), do: :error
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,27 +2,24 @@ defmodule EctoFields.Mixfile do
   use Mix.Project
 
   def project() do
-    [app: :ecto_fields,
-     version: "1.1.4",
-     elixir: "~> 1.2",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps(),
-     package: package(),
-     description: description()]
-  end
-
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
-  def application() do
-    [applications: [:logger]]
+    [
+      app: :ecto_fields,
+      version: "1.1.4",
+      elixir: "~> 1.2",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      package: package(),
+      description: description()
+    ]
   end
 
   def package() do
-    [licenses: ["MIT"],
-     maintainers: ["jerel"],
-     links: %{"GitHub" => "https://github.com/jerel/ecto_fields"}]
+    [
+      licenses: ["MIT"],
+      maintainers: ["jerel"],
+      links: %{"GitHub" => "https://github.com/jerel/ecto_fields"}
+    ]
   end
 
   def description() do
@@ -41,8 +38,11 @@ defmodule EctoFields.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps() do
-    [{:ecto, "~> 2.0"},
-     {:ex_doc, ">= 0.0.0", only: :dev},
-     {:mix_test_watch, "~> 0.2", only: :dev}]
+    [
+      {:ecto, "~> 2.0"},
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:mix_test_watch, "~> 0.2", only: :dev},
+      {:propcheck, "~> 1.0.5", only: :test}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,11 @@
-%{"decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [:mix], [], "hexpm"},
+%{
+  "decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.2.6", "3fd1067661d6d64851a0d4db9acd9e884c00d2d1aa41cc09da687226cf894661", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.5.0", "2c322d119a4795c3431380fca2bca5afa4dc07324bd3c0b9f6b2efbdd99f5ed3", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"}}
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+  "propcheck": {:hex, :propcheck, "1.0.5", "0d6be01f57c9c1046610d6b02f013cc9e87b2ca3901e39c2266554045695c0d1", [:mix], [{:proper, "~> 1.2.0", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
+  "proper": {:hex, :proper, "1.2.0", "1466492385959412a02871505434e72e92765958c60dba144b43863554b505a4", [:make, :mix, :rebar3], [], "hexpm"},
+}

--- a/test/ecto_fields_test.exs
+++ b/test/ecto_fields_test.exs
@@ -1,14 +1,55 @@
 defmodule EctoFieldsTest do
   use ExUnit.Case
-  doctest EctoFields
+  use PropCheck
 
-  doctest EctoFields.Email
-  doctest EctoFields.IP
-  doctest EctoFields.IPv4
-  doctest EctoFields.IPv6
-  doctest EctoFields.PositiveInteger
-  doctest EctoFields.Slug
-  doctest EctoFields.URL
-  doctest EctoFields.Atom
-  doctest EctoFields.Static
+  doctest(EctoFields)
+
+  doctest(EctoFields.Email)
+  doctest(EctoFields.IP)
+  doctest(EctoFields.IPv4)
+  doctest(EctoFields.IPv6)
+  doctest(EctoFields.PositiveInteger)
+  doctest(EctoFields.Slug)
+  doctest(EctoFields.URL)
+  doctest(EctoFields.Atom)
+  doctest(EctoFields.Static)
+
+  property("EctoFields.Atom") do
+    forall(atom in oneof([atom(), atom_utf8()])) do
+      string = Atom.to_string(atom)
+
+      {:ok, atom} == EctoFields.Atom.cast(string) and {:ok, atom} == EctoFields.Atom.load(string) and
+        {:ok, string} == EctoFields.Atom.dump(atom)
+    end
+  end
+
+  @doc false
+  defp atom_utf8() do
+    :proper_types.new_type(
+      [
+        {:generator, &atom_utf8_gen/1},
+        {:reverse_gen, &atom_utf8_rev/1},
+        {:size_transform, fn size -> :erlang.min(size, 255) end},
+        {:is_instance, &atom_utf8_is_instance/1}
+      ],
+      :wrapper
+    )
+  end
+
+  @doc false
+  defp atom_utf8_gen(size) when is_integer(size) and size >= 0 do
+    let(string <- such_that(x <- :proper_unicode.utf8(size), when: x === <<>> or :binary.first(x) !== ?$)) do
+      :erlang.binary_to_atom(string, :utf8)
+    end
+  end
+
+  @doc false
+  defp atom_utf8_rev(atom) when is_atom(atom) do
+    {:"$used", :erlang.atom_to_list(atom), atom}
+  end
+
+  @doc false
+  defp atom_utf8_is_instance(x) do
+    is_atom(x) and (x === :"" or :erlang.hd(:erlang.atom_to_list(x)) !== ?$)
+  end
 end


### PR DESCRIPTION
Based on the comment I made about using this for labs, I made the following changes to `EctoFields.Atom`:

* Adjusted `cast/1` to only attempt casting strings that are less than or equal to 255 bytes (maximum length of an atom).
* Changed `load/1` to simply be an alias to `cast/1`.
* Adjusted `dump/1` to dump both atoms and strings that are less than or equal to 255 bytes.
* Added simple property test using PropEr.
* Formatted any files I touched.