### PR TITLE
Use strict address parsing in EctoFields.IP.cast()

### DIFF
--- a/lib/fields/ip.ex
+++ b/lib/fields/ip.ex
@@ -18,7 +18,7 @@ defmodule EctoFields.IP do
       :error
   """
   def cast(ip) when is_binary(ip) and byte_size(ip) > 0 do
-    case ip |> String.to_charlist() |> :inet_parse.address() do
+    case ip |> String.to_charlist() |> :inet.parse_strict_address() do
       {:ok, _} -> {:ok, ip}
       {:error, _} -> :error
     end


### PR DESCRIPTION
Both EctoFields.IPv4 and EctoFields.IPv6 use strict address parsing in
their cast, update EctoFields.IP to match.  Prevents validation of plain
integers and other obscure short-form IPv4 addresses.